### PR TITLE
Remove deprecated --resume-download huggingface-cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ huggingface-cli download --resume-download ICTNLP/cosy2_decoder --local-dir mode
 
 ```shell
 model_name=LLaMA-Omni2-7B-Bilingual
-huggingface-cli download --resume-download ICTNLP/$model_name --local-dir models/$model_name
+huggingface-cli download ICTNLP/$model_name --local-dir models/$model_name
 ```
 
 | LLaMA-Omni2                                                           | LLaMA-Omni2-Bilingual                                                                     |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ model = whisper.load_model("large-v3", download_root="models/speech_encoder/")
 2. Download the flow-matching model and vocoder of `CosyVoice 2`.
 
 ```shell
-huggingface-cli download --resume-download ICTNLP/cosy2_decoder --local-dir models/cosy2_decoder
+huggingface-cli download ICTNLP/cosy2_decoder --local-dir models/cosy2_decoder
 ```
 
 > [!Tip]


### PR DESCRIPTION
From huggingface docs:
resume_download is deprecated and will be removed in version 1.0.0. Downloads always resume when possible.

Hopefully this will prevent something breaking in the future